### PR TITLE
Download unlisted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ This SDK builds a layer of abstraction above customerconnect.vmware.com to hide 
 
 ## Usage
 See test `TestFetchDownloadLinkVersionGlob` in `download_test.go` for an end to end example of how to use the SDK to download a file based on a version glob, meaning the latest version matching the pattern is downloaded.
+
+By setting product to "DownloadGroup", subroduct to an actual download group and version to a productId you can download files that are not part of the official product lists.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/idstam/vmware-download-sdk
+module github.com/laidbackware/vmware-download-sdk
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/laidbackware/vmware-download-sdk
+module github.com/idstam/vmware-download-sdk
 
 go 1.16
 

--- a/sdk/dlg_details.go
+++ b/sdk/dlg_details.go
@@ -148,6 +148,14 @@ func (c *Client) GetFileArray(slug, subProduct, version string) (data []string, 
 }
 
 func (c *Client) GetDlgProduct(slug, subProduct, version string) (downloadGroup, productID string, err error) {
+
+	//If the keyword is given just return the supplied downloadGroup and productID
+	if slug == downloadGroupKeyword {
+		downloadGroup = subProduct
+		productID = version
+		return
+	}
+
 	// Find the API version details
 	var apiVersion APIVersions
 	apiVersion, err = c.FindVersion(slug, subProduct, version)

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -28,6 +28,8 @@ type AuthorizedDownload struct {
 
 const (
 	downloadURL = baseURL + "/channel/api/v1.0/dlg/download"
+	//Keyword to use a product to force download of a given DownloadGroup and productId
+	downloadGroupKeyword = "DownloadGroup"
 )
 
 var ErrorInvalidDownloadPayload = errors.New("download: invalid download payload")
@@ -41,9 +43,12 @@ func (c *Client) GenerateDownloadPayload(slug, subProduct, version, fileName str
 		return
 	}
 
-	if _, ok := ProductDetailMap[slug]; !ok {
-		err = ErrorInvalidSlug
-		return
+	//If the key word is given there's no need to validate the product
+	if slug != downloadGroupKeyword {
+		if _, ok := ProductDetailMap[slug]; !ok {
+			err = ErrorInvalidSlug
+			return
+		}
 	}
 
 	var downloadGroup, productID string

--- a/sdk/download_test.go
+++ b/sdk/download_test.go
@@ -97,3 +97,24 @@ func TestGenerateDownloadDoubleVersion(t *testing.T) {
 	assert.ErrorIs(t, err, ErrorMultipleVersionGlob)
 	assert.Empty(t, downloadPayload, "Expected response to be empty")
 }
+
+func TestFetshUnlistedProductLink(t *testing.T) {
+	err = ensureLogin(t)
+	require.Nil(t, err)
+
+	var downloadPayload []DownloadPayload
+	downloadPayload, err = authenticatedClient.GenerateDownloadPayload("DownloadGroup", "OEM-ESXI70U3-HPE", "974", "VMware-ESXi-7.0.3-19193900-HPE-*-Synergy-depot.zip", true)
+	assert.Nil(t, err)
+	require.NotEmpty(t, downloadPayload)
+	assert.NotEmpty(t, downloadPayload[0].ProductId, "Expected response not to be empty")
+
+	t.Logf(fmt.Sprintf("download_payload: %+v\n", downloadPayload))
+
+	var authorizedDownload AuthorizedDownload
+	authorizedDownload, _ = authenticatedClient.FetchDownloadLink(downloadPayload[0])
+	assert.Nil(t, err)
+	assert.NotEmpty(t, authorizedDownload.DownloadURL, "Expected response not to be empty")
+
+	t.Logf(fmt.Sprintf("download_details: %+v\n", authorizedDownload))
+
+}


### PR DESCRIPTION
This is a response to the issue in vmd: https://github.com/laidbackware/vmd/issues/1

By setting product to "DownloadGroup", subroduct to an actual download group and version to a productId you can download files that are not part of the official product lists.

This allows us to download files even though they are not discoverable with the product listings.

It's not very nice to overload parameters like that, but it made for a very small change.